### PR TITLE
Only link stdc++fs with GCC < 9.0

### DIFF
--- a/llvm/lib/CodeGen/CMakeLists.txt
+++ b/llvm/lib/CodeGen/CMakeLists.txt
@@ -196,8 +196,9 @@ add_llvm_component_library(LLVMCodeGen
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/CodeGen
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/CodeGen/PBQP
 
-  LINK_LIBS ${LLVM_PTHREAD_LIB}
-  LINK_LIBS stdc++fs
+  LINK_LIBS
+  ${LLVM_PTHREAD_LIB}
+  $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>
 
   DEPENDS
   intrinsics_gen


### PR DESCRIPTION
While `-lstdc++fs` is necessary when compiling with GCC 8.x, more recent compilers (e. g. clang 13) complain about the library not being present. See https://gitlab.kitware.com/cmake/cmake/-/issues/17834 for more details on the problem and the possible solutions.

I did test this solution with clang 13 on macOS, however I did not test it with GCC 8.x.